### PR TITLE
feat: implement v0.1.0-beta.1 blockers

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -699,7 +699,7 @@ The roadmap below integrates audit findings, EARS requirements, and TLA+ conform
 |---|------|---------|-----|-----------------|--------|
 | 8 | Extend `in_step` guard to all mutating APIs | M1 | REQ-EX-004 | ReentrancyMinimal | Medium |
 | 9 | Sync framebuffer from engine (replace synthetic test pattern) | H8 | REQ-CP-001 | CaptureMinimal | Medium |
-| 10 | Resolve dual runtime path divergence (`dosbox_step` vs `dosbox_lib_step_cycles`) | M10 | REQ-EX-001 | — | Medium |
+| 10 | ~~Resolve dual runtime path divergence (`dosbox_step` vs `dosbox_lib_step_cycles`)~~ **RESOLVED** (REQ-LC-005) | M10 | REQ-EX-001 | — | Medium |
 | 11 | Guard `dosbox_lib_get_context_ptr()` return in `legends_step_cycles` | M11 | REQ-ER-003 | ErrorModel | Small |
 | 12 | Exception-safe callback invocation at C ABI boundary | M6 | REQ-ER-004 | — | Small |
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,6 +696,7 @@ if(LEGENDS_BUILD_TESTS)
         tests/unit/test_fullscreen_toggle.cpp
         tests/unit/test_joystick_mapper.cpp
         tests/unit/test_shader_presets.cpp
+        tests/unit/test_shader_size_limit.cpp
         tests/unit/test_ai_config.cpp
         tests/unit/test_ai_screen_context.cpp
         tests/unit/test_ai_http_client.cpp

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -72,7 +72,7 @@ The system shall route all step execution through the CPU bridge (`dosbox::execu
 |---|---|
 | Source | AUDIT M10 (dual runtime path), H3 (MachineContext.step stub) |
 | Evidence | `dosbox_context.cpp:920` routes through stub; `dosbox_library.cpp:371` routes through bridge |
-| Status | **GAP** — `dosbox_step()` routes through TODO stub, `dosbox_lib_step_cycles()` uses real bridge |
+| Status | **RESOLVED** — `dosbox_step()`, `DOSBoxContext::step()`, `MachineContext::step()`, and `MachineContext::run()` removed (REQ-LC-005). Single execution path via `dosbox_lib_step_cycles()`. |
 
 ### REQ-LC-006 No Phantom Definitions [Ubiquitous]
 

--- a/engine/include/aibox/machine_context.h
+++ b/engine/include/aibox/machine_context.h
@@ -29,16 +29,6 @@
 
 namespace aibox {
 
-// Forward declarations for subsystem types used in MachineContext interface.
-// These are intentionally unimplemented — initialization delegates to DOSBox-X engine bridge.
-class VgaContext;
-class DosKernel;
-class PicController;
-class PitTimer;
-class KeyboardController;
-class MouseController;
-class SoundSubsystem;
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Machine State
 // ─────────────────────────────────────────────────────────────────────────────
@@ -165,13 +155,13 @@ struct MachineConfig {
  * ## Lifecycle
  * 1. Create: `MachineContext ctx(config)`
  * 2. Initialize: `ctx.initialize()`
- * 3. Run: `ctx.step(ms)` or `ctx.run()`
+ * 3. Run: via `dosbox_lib_step_cycles()` (production path)
  * 4. Shutdown: `ctx.shutdown()`
  *
  * ## State Machine
  * @verbatim
  *   Created -> [initialize] -> Initialized
- *   Initialized -> [step/run] -> Running
+ *   Initialized -> [dosbox_lib_step_cycles] -> Running
  *   Running -> [pause] -> Paused
  *   Running -> [stop] -> Stopped
  *   Paused -> [resume] -> Running
@@ -194,9 +184,7 @@ struct MachineConfig {
  *       return;
  *   }
  *
- *   while (ctx.state() == MachineState::Running) {
- *       ctx.step(10);  // Run 10ms
- *   }
+ *   // Execution is driven by dosbox_lib_step_cycles() (production path)
  *
  *   ctx.shutdown();
  * @endcode
@@ -256,36 +244,9 @@ public:
     Result<void> initialize();
 
     /**
-     * @brief Execute emulation for specified duration.
-     *
-     * Executes the specified number of milliseconds of emulated
-     * time. The actual execution time depends on host performance.
-     *
-     * @param ms Milliseconds of emulated time to execute
-     * @return Result with actual steps executed or error
-     *
-     * @pre state() == Initialized, Running, or Paused
-     * @post state() == Running (or Stopped if stop requested)
-     */
-    Result<uint32_t> step(uint32_t ms);
-
-    /**
-     * @brief Run until stop requested.
-     *
-     * Blocks until request_stop() is called or error occurs.
-     * Suitable for simple use cases without external event loop.
-     *
-     * @return Result indicating completion reason
-     *
-     * @pre state() == Initialized
-     * @post state() == Stopped
-     */
-    Result<void> run();
-
-    /**
      * @brief Request stop from another thread.
      *
-     * Thread-safe. Sets flag checked by run/step loop.
+     * Thread-safe. Sets flag checked by the execution loop.
      * The emulator will stop at the next safe point.
      *
      * @note This is the ONLY thread-safe method.
@@ -350,15 +311,6 @@ public:
 
     /** @brief DMA subsystem (nullptr until initialized) */
     std::unique_ptr<DmaSubsystem> dma;
-
-    // Future subsystems (nullptr until implemented)
-    // std::unique_ptr<VgaContext> vga;
-    // std::unique_ptr<DosKernel> dos;
-    // std::unique_ptr<PicController> pic;
-    // std::unique_ptr<PitTimer> pit;
-    // std::unique_ptr<KeyboardController> keyboard;
-    // std::unique_ptr<MouseController> mouse;
-    // std::unique_ptr<SoundSubsystem> sound;
 
     // ─────────────────────────────────────────────────────────────────────────
     // State Queries
@@ -453,14 +405,7 @@ private:
         None,
         Memory,
         Cpu,
-        Pic,
-        Pit,
         Dma,
-        Vga,
-        Input,
-        Sound,
-        Dos,
-        Bios,
         Complete
     };
 
@@ -472,14 +417,7 @@ private:
 
     Result<void> init_memory();
     Result<void> init_cpu();
-    Result<void> init_pic();
-    Result<void> init_pit();
     Result<void> init_dma();
-    Result<void> init_vga();
-    Result<void> init_input();
-    Result<void> init_sound();
-    Result<void> init_dos();
-    Result<void> init_bios();
 
     /**
      * @brief Cleanup subsystems down to specified stage.

--- a/engine/include/dosbox/dosbox_context.h
+++ b/engine/include/dosbox/dosbox_context.h
@@ -37,6 +37,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,21 +83,12 @@ dosbox_handle_t dosbox_create(const dosbox_config* config);
 /**
  * @brief Initialize a created instance.
  *
- * Must be called before step/run.
+ * Must be called before run.
  *
  * @param handle Instance handle
  * @return DOSBOX_OK on success, error code on failure
  */
 int dosbox_init(dosbox_handle_t handle);
-
-/**
- * @brief Execute emulation for specified duration.
- *
- * @param handle Instance handle
- * @param ms Milliseconds of emulated time
- * @return DOSBOX_OK on success, error code on failure
- */
-int dosbox_step(dosbox_handle_t handle, uint32_t ms);
 
 /**
  * @brief Pause execution.
@@ -397,6 +389,7 @@ struct MixerState {
     MixerState& operator=(const MixerState&) = delete;
 
     MixerState(MixerState&& o) noexcept
+        // mutex intentionally not moved — destination gets a fresh default-constructed mutex
         : freq(o.freq), blocksize(o.blocksize)
         , mastervol{o.mastervol[0], o.mastervol[1]}
         , recordvol{o.recordvol[0], o.recordvol[1]}
@@ -415,6 +408,7 @@ struct MixerState {
     {}
 
     MixerState& operator=(MixerState&& o) noexcept {
+        // mutex intentionally not assigned — each instance owns its own mutex
         freq = o.freq; blocksize = o.blocksize;
         mastervol[0] = o.mastervol[0]; mastervol[1] = o.mastervol[1];
         recordvol[0] = o.recordvol[0]; recordvol[1] = o.recordvol[1];
@@ -432,6 +426,14 @@ struct MixerState {
         start_pic_time = o.start_pic_time;
         return *this;
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Synchronization
+    // Acquired before any other lock in the system (mutex ordering rule).
+    // mutable so const methods (hash_into) can lock it.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    mutable std::mutex mutex;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Core Configuration (from mixer struct, lines 94-95)
@@ -497,6 +499,7 @@ struct MixerState {
      * @brief Reset to initial state.
      */
     void reset() noexcept {
+        std::lock_guard<std::mutex> lock(mutex);
         freq = 44100;
         blocksize = 1024;
         mastervol[0] = mastervol[1] = 1.0f;
@@ -1591,11 +1594,6 @@ public:
      * @brief Initialize all subsystems.
      */
     [[nodiscard]] Result<void> initialize();
-
-    /**
-     * @brief Execute emulation for specified duration.
-     */
-    [[nodiscard]] Result<uint32_t> step(uint32_t ms);
 
     /**
      * @brief Pause execution.

--- a/engine/include/dosbox/engine_state.h
+++ b/engine/include/dosbox/engine_state.h
@@ -246,9 +246,30 @@ struct EngineStateCpu {
     uint8_t nmi_active;          ///< CPU_NMI_active
     uint8_t nmi_pending;         ///< CPU_NMI_pending
     uint8_t halted;              ///< CPU in HLT state
-    uint8_t _pad[6];
+
+    // CPU General Purpose Registers (REQ-SR-002)
+    uint32_t reg_eax = 0;
+    uint32_t reg_ecx = 0;
+    uint32_t reg_edx = 0;
+    uint32_t reg_ebx = 0;
+    uint32_t reg_esp = 0;
+    uint32_t reg_ebp = 0;
+    uint32_t reg_esi = 0;
+    uint32_t reg_edi = 0;
+    uint32_t reg_eip = 0;
+    uint32_t reg_eflags = 0;
+
+    // Segment Registers
+    uint16_t seg_cs = 0;
+    uint16_t seg_ds = 0;
+    uint16_t seg_es = 0;
+    uint16_t seg_fs = 0;
+    uint16_t seg_gs = 0;
+    uint16_t seg_ss = 0;
+
+    uint8_t _pad[10];
 };
-static_assert(sizeof(EngineStateCpu) == 96, "EngineStateCpu must be 96 bytes");
+static_assert(sizeof(EngineStateCpu) == 152, "EngineStateCpu must be 152 bytes");
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Memory State Section [V2]
@@ -372,7 +393,7 @@ static_assert(sizeof(EngineStateDos) == 20, "EngineStateDos must be 20 bytes");
  * @brief V5 extension header, appended after V4 data at offset ENGINE_STATE_SIZE_V4.
  *
  * V4 loaders reject V5 data via version check. V5 loaders read V4 data
- * normally, then read this extension header at offset 680.
+ * normally, then read this extension header at offset 736.
  */
 struct EngineStateV5ExtHeader {
     uint32_t ext_magic;          ///< ENGINE_STATE_V5_EXT_MAGIC
@@ -418,7 +439,7 @@ constexpr uint16_t V5_SUBTAG_VRAM    = 4;  ///< VGA VRAM contents (zero-RLE comp
 constexpr uint16_t V5_BLOCK_FLAG_COMPRESSED = 0x0001;  ///< Block is zero-RLE compressed
 
 /**
- * @brief V5 sub-block directory header, placed at offset 792 (after CpuGpr).
+ * @brief V5 sub-block directory header, placed at offset 848 (after CpuGpr).
  *
  * Contains magic and entry count. Unknown tags are skipped via offset+size.
  */
@@ -614,7 +635,7 @@ constexpr size_t ENGINE_STATE_SIZE_V3 =
     sizeof(EngineStateCpu) +
     sizeof(EngineStateMemory);
 
-static_assert(ENGINE_STATE_SIZE_V3 == 544, "V3 size must be 544 bytes");
+static_assert(ENGINE_STATE_SIZE_V3 == 600, "V3 size must be 600 bytes");
 
 /**
  * @brief Total size for V4 engine state (backward compat baseline).
@@ -630,7 +651,7 @@ constexpr size_t ENGINE_STATE_SIZE_V4 =
     sizeof(EngineStateVga) +
     sizeof(EngineStateDos);
 
-static_assert(ENGINE_STATE_SIZE_V4 == 680, "ENGINE_STATE_SIZE_V4 must be 680 bytes");
+static_assert(ENGINE_STATE_SIZE_V4 == 736, "ENGINE_STATE_SIZE_V4 must be 736 bytes");
 
 /**
  * @brief Minimum V5 state size (V4 + GPR extension, no sub-block blobs).
@@ -643,7 +664,7 @@ constexpr size_t ENGINE_STATE_SIZE_V5_BASE =
     sizeof(EngineStateV5ExtHeader) +
     sizeof(EngineStateCpuGpr);
 
-static_assert(ENGINE_STATE_SIZE_V5_BASE == 792, "ENGINE_STATE_SIZE_V5_BASE must be 792 bytes");
+static_assert(ENGINE_STATE_SIZE_V5_BASE == 848, "ENGINE_STATE_SIZE_V5_BASE must be 848 bytes");
 
 /// @deprecated Use ENGINE_STATE_SIZE_V5_BASE for compile-time minimum.
 /// Actual V5 size is dynamic — query via dosbox_lib_save_state(nullptr).

--- a/engine/src/aibox/machine_context.cpp
+++ b/engine/src/aibox/machine_context.cpp
@@ -136,123 +136,16 @@ Result<void> MachineContext::initialize() {
     }
     init_stage_ = InitStage::Cpu;
 
-    result = init_pic();
+    result = init_dma();
     if (!result.has_value()) {
         cleanup_to_stage(InitStage::Cpu);
         return result;
     }
-    init_stage_ = InitStage::Pic;
-
-    result = init_pit();
-    if (!result.has_value()) {
-        cleanup_to_stage(InitStage::Pic);
-        return result;
-    }
-    init_stage_ = InitStage::Pit;
-
-    result = init_dma();
-    if (!result.has_value()) {
-        cleanup_to_stage(InitStage::Pit);
-        return result;
-    }
     init_stage_ = InitStage::Dma;
 
-    result = init_vga();
-    if (!result.has_value()) {
-        cleanup_to_stage(InitStage::Dma);
-        return result;
-    }
-    init_stage_ = InitStage::Vga;
-
-    result = init_input();
-    if (!result.has_value()) {
-        cleanup_to_stage(InitStage::Vga);
-        return result;
-    }
-    init_stage_ = InitStage::Input;
-
-    if (config_.sound_enabled) {
-        result = init_sound();
-        if (!result.has_value()) {
-            cleanup_to_stage(InitStage::Input);
-            return result;
-        }
-    }
-    init_stage_ = InitStage::Sound;
-
-    result = init_dos();
-    if (!result.has_value()) {
-        cleanup_to_stage(InitStage::Sound);
-        return result;
-    }
-    init_stage_ = InitStage::Dos;
-
-    result = init_bios();
-    if (!result.has_value()) {
-        cleanup_to_stage(InitStage::Dos);
-        return result;
-    }
     init_stage_ = InitStage::Complete;
 
     state_ = MachineState::Initialized;
-    return Ok();
-}
-
-// DEPRECATED(M10): This stub does not execute real CPU instructions.
-// All production step execution routes through dosbox_lib_step_cycles() ->
-// dosbox::execute_cycles() in cpu_bridge.cpp. This stub only increments
-// counters and will be removed in a future cleanup pass.
-Result<uint32_t> MachineContext::step(uint32_t ms) {
-    // Check precondition (REQ-GSE-020, REQ-GSE-021)
-    if (state_ != MachineState::Initialized &&
-        state_ != MachineState::Running &&
-        state_ != MachineState::Paused) {
-        auto err = Error(ErrorCode::InvalidState,
-            "Cannot step in current state");
-        set_error(err);
-        return Err(std::move(err));
-    }
-
-    // Set this as current context for compatibility shim (REQ-GSE-013)
-    compat::ContextGuard guard(*this);
-
-    state_ = MachineState::Running;
-
-    uint32_t steps = 0;
-    try {
-        for (uint32_t t = 0; t < ms && !stop_requested_.load(std::memory_order_acquire); t++) {
-            virtual_ticks_ms_++;
-
-            uint32_t cycles_this_ms = config_.cpu_cycles;
-            total_cycles_ += cycles_this_ms;
-
-            // No real CPU execution — counter increment only (see deprecation note)
-
-            steps++;
-        }
-    } catch (const EmulatorException& e) {
-        auto err = Error(ErrorCode::CpuError, e.what());
-        set_error(err);
-        state_ = MachineState::Stopped;
-        return Err(std::move(err));
-    }
-
-    if (stop_requested_.load(std::memory_order_acquire)) {
-        state_ = MachineState::Stopped;
-        stop_requested_.store(false, std::memory_order_release);
-    }
-
-    return Ok(steps);
-}
-
-Result<void> MachineContext::run() {
-    while (state_ == MachineState::Running ||
-           state_ == MachineState::Initialized) {
-        auto result = step(100);  // 100ms chunks
-        if (!result.has_value()) {
-            return Err(result.error());
-        }
-    }
     return Ok();
 }
 
@@ -318,30 +211,8 @@ Result<void> MachineContext::reset() {
 
 void MachineContext::cleanup_to_stage(InitStage target) noexcept {
     // Cleanup from current stage down to target (REQ-GSE-012, REQ-GSE-043)
-    if (init_stage_ >= InitStage::Complete && target < InitStage::Complete) {
-        // Cleanup BIOS - nothing to do for now
-    }
-    if (init_stage_ >= InitStage::Dos && target < InitStage::Dos) {
-        // dos.reset();
-    }
-    if (init_stage_ >= InitStage::Sound && target < InitStage::Sound) {
-        // sound.reset();
-    }
-    if (init_stage_ >= InitStage::Input && target < InitStage::Input) {
-        // keyboard.reset();
-        // mouse.reset();
-    }
-    if (init_stage_ >= InitStage::Vga && target < InitStage::Vga) {
-        // vga.reset();
-    }
     if (init_stage_ >= InitStage::Dma && target < InitStage::Dma) {
         dma.reset();
-    }
-    if (init_stage_ >= InitStage::Pit && target < InitStage::Pit) {
-        // pit.reset();
-    }
-    if (init_stage_ >= InitStage::Pic && target < InitStage::Pic) {
-        // pic.reset();
     }
     if (init_stage_ >= InitStage::Cpu && target < InitStage::Cpu) {
         cpu.reset();
@@ -373,47 +244,8 @@ Result<void> MachineContext::init_cpu() {
     return Ok();
 }
 
-// H4/M5: These init stubs delegate to DOSBox-X engine bridge.
-// Initialization is handled by dosbox_lib_init() -> DOSBoxContext.
-// Kept for MachineContext interface compatibility but are intentional no-ops.
-
-Result<void> MachineContext::init_pic() {
-    // Initialization handled by DOSBox-X engine bridge
-    return Ok();
-}
-
-Result<void> MachineContext::init_pit() {
-    // Initialization handled by DOSBox-X engine bridge
-    return Ok();
-}
-
 Result<void> MachineContext::init_dma() {
     dma = std::make_unique<DmaSubsystem>();
-    return Ok();
-}
-
-Result<void> MachineContext::init_vga() {
-    // Initialization handled by DOSBox-X engine bridge
-    return Ok();
-}
-
-Result<void> MachineContext::init_input() {
-    // Initialization handled by DOSBox-X engine bridge
-    return Ok();
-}
-
-Result<void> MachineContext::init_sound() {
-    // Initialization handled by DOSBox-X engine bridge
-    return Ok();
-}
-
-Result<void> MachineContext::init_dos() {
-    // Initialization handled by DOSBox-X engine bridge
-    return Ok();
-}
-
-Result<void> MachineContext::init_bios() {
-    // Initialization handled by DOSBox-X engine bridge
     return Ok();
 }
 

--- a/engine/src/misc/dosbox_context.cpp
+++ b/engine/src/misc/dosbox_context.cpp
@@ -134,6 +134,7 @@ void CpuState::hash_into(HashBuilder& builder) const {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 void MixerState::hash_into(HashBuilder& builder) const {
+    std::lock_guard<std::mutex> lock(mutex);
     // Hash determinism-relevant mixer state
     // Note: We do NOT hash start_pic_time as it's wall-clock dependent
 
@@ -970,42 +971,6 @@ int dosbox_init(dosbox_handle_t handle) {
     return DOSBOX_OK;
 }
 
-// DEPRECATED(M10): Routes through MachineContext::step() which is a counter-
-// incrementing stub. Production code uses dosbox_lib_step_cycles() instead.
-// Only called from test_dosbox_context.cpp. Will be removed in a future pass.
-int dosbox_step(dosbox_handle_t handle, uint32_t ms) {
-    auto h = dosbox::InstanceHandle::from_opaque(handle);
-    auto* ctx = dosbox::get_context(h);
-    if (!ctx) {
-        return DOSBOX_ERR_INVALID_ARGUMENT;
-    }
-
-    auto& registry = dosbox::get_instance_registry();
-
-    // Check state allows running
-    auto state = registry.get_state(h);
-    if (!state || (state.value() != dosbox::InstanceState::Initialized &&
-                   state.value() != dosbox::InstanceState::Running &&
-                   state.value() != dosbox::InstanceState::Paused)) {
-        return DOSBOX_ERR_INVALID_STATE;
-    }
-
-    // Transition to Running if not already
-    if (state.value() != dosbox::InstanceState::Running) {
-        registry.transition(h, dosbox::InstanceState::Running);
-    }
-
-    // Set current context for transitional code
-    dosbox::ContextGuard guard(*ctx);
-
-    auto result = ctx->step(ms);
-    if (!result.has_value()) {
-        return static_cast<int>(result.error().code());
-    }
-
-    return DOSBOX_OK;
-}
-
 int dosbox_pause(dosbox_handle_t handle) {
     auto h = dosbox::InstanceHandle::from_opaque(handle);
     auto& registry = dosbox::get_instance_registry();
@@ -1173,7 +1138,10 @@ Result<void> DOSBoxContext::initialize() {
 
     // Apply configuration
     cpu_state.cycle_limit = config_.cpu_cycles;
-    mixer.enabled = config_.sound_enabled;
+    {
+        std::lock_guard<std::mutex> lock(mixer.mutex);
+        mixer.enabled = config_.sound_enabled;
+    }
 
     // TODO: In future PRs, this will initialize actual DOSBox subsystems
     // For now, we just set the initialized flag
@@ -1182,27 +1150,6 @@ Result<void> DOSBoxContext::initialize() {
     stop_requested_ = false;
 
     return Ok();
-}
-
-// DEPRECATED(M10): Counter-incrementing stub — does not execute real CPU
-// instructions. Production code uses dosbox::execute_cycles() via cpu_bridge.cpp.
-Result<uint32_t> DOSBoxContext::step(uint32_t ms) {
-    if (!initialized_) {
-        return Err(Error(ErrorCode::InvalidState, "Not initialized"));
-    }
-
-    if (stop_requested_.load(std::memory_order_acquire)) {
-        return Err(Error(ErrorCode::InvalidState, "Stop requested"));
-    }
-
-    uint32_t cycles = ms * config_.cpu_cycles;
-
-    // No real CPU execution — counter increment only (see deprecation note)
-    timing.total_cycles += cycles;
-    timing.virtual_ticks_ms += ms;
-    cpu_state.cycles += cycles;
-
-    return Ok(cycles);
 }
 
 Result<void> DOSBoxContext::pause() {
@@ -1271,7 +1218,10 @@ Result<void> DOSBoxContext::reset() {
 
     // Reapply configuration
     cpu_state.cycle_limit = config_.cpu_cycles;
-    mixer.enabled = config_.sound_enabled;
+    {
+        std::lock_guard<std::mutex> lock(mixer.mutex);
+        mixer.enabled = config_.sound_enabled;
+    }
 
     stop_requested_ = false;
 

--- a/engine/src/misc/dosbox_library.cpp
+++ b/engine/src/misc/dosbox_library.cpp
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <algorithm>
+#include <filesystem>
 
 #include <atomic>
 #include <memory>
@@ -573,7 +574,7 @@ dosbox_lib_error_t dosbox_lib_save_state(
     if (has_vga_hw) sub_block_count += 2;  // VGA_REG + VRAM
 
     // Calculate total size needed (dynamic)
-    size_t total = dosbox::ENGINE_STATE_SIZE_V5_BASE;  // 792 base
+    size_t total = dosbox::ENGINE_STATE_SIZE_V5_BASE;  // 848 base
 
     if (sub_block_count > 0) {
         total += sizeof(dosbox::V5SubBlockDir);                         // 8
@@ -739,6 +740,33 @@ dosbox_lib_error_t dosbox_lib_save_state(
     cpu.nmi_active = ctx->cpu_state.nmi_active ? 1 : 0;
     cpu.nmi_pending = ctx->cpu_state.nmi_pending ? 1 : 0;
     cpu.halted = ctx->cpu_state.halted ? 1 : 0;
+    // CPU GPR state (REQ-SR-002) — snapshot x86 register file into EngineStateCpu
+    {
+        uint32_t gpr[8] = {};
+        uint32_t eip = 0, eflags = 0;
+        uint16_t seg_val[6] = {};
+        uint32_t seg_phys[6] = {};
+        uint32_t seg_limit[6] = {};
+        dosbox::snapshot_cpu_gprs(gpr, eip, eflags, seg_val, seg_phys, seg_limit);
+        // GPR order: EAX(0), ECX(1), EDX(2), EBX(3), ESP(4), EBP(5), ESI(6), EDI(7)
+        cpu.reg_eax = gpr[0];
+        cpu.reg_ecx = gpr[1];
+        cpu.reg_edx = gpr[2];
+        cpu.reg_ebx = gpr[3];
+        cpu.reg_esp = gpr[4];
+        cpu.reg_ebp = gpr[5];
+        cpu.reg_esi = gpr[6];
+        cpu.reg_edi = gpr[7];
+        cpu.reg_eip    = eip;
+        cpu.reg_eflags = eflags;
+        // Segment order: ES(0), CS(1), SS(2), DS(3), FS(4), GS(5)
+        cpu.seg_es = seg_val[0];
+        cpu.seg_cs = seg_val[1];
+        cpu.seg_ss = seg_val[2];
+        cpu.seg_ds = seg_val[3];
+        cpu.seg_fs = seg_val[4];
+        cpu.seg_gs = seg_val[5];
+    }
     std::memcpy(ptr + header.cpu_offset, &cpu, sizeof(cpu));
 
     // Serialize Memory state (H2: local struct + memcpy)
@@ -835,7 +863,7 @@ dosbox_lib_error_t dosbox_lib_save_state(
     }
 
     // ─── Phase 3: Serialize RAM + VGA sub-blocks ────────────────────────
-    size_t actual_total = dosbox::ENGINE_STATE_SIZE_V5_BASE;  // 792
+    size_t actual_total = dosbox::ENGINE_STATE_SIZE_V5_BASE;  // 848
 
     if (sub_block_count > 0) {
         // Cursor for blob data (after directory)
@@ -907,7 +935,7 @@ dosbox_lib_error_t dosbox_lib_save_state(
         actual_total = blob_cursor;
     }
 
-    // Update ext_size in V5 extension header to cover all data from offset 680
+    // Update ext_size in V5 extension header to cover all data from offset 736
     {
         dosbox::EngineStateV5ExtHeader ext_hdr{};
         ext_hdr.ext_magic = dosbox::ENGINE_STATE_V5_EXT_MAGIC;
@@ -997,10 +1025,16 @@ dosbox_lib_error_t dosbox_lib_load_state(
         ? sizeof(dosbox::EngineStatePicV3)
         : sizeof(dosbox::EngineStatePic);
 
+    // V4 and below: EngineStateCpu was 96 bytes (no GPR fields); V5+: 152 bytes
+    constexpr size_t CPU_SECTION_SIZE_LEGACY = 96;
+    size_t cpu_section_size = (header.version <= 4)
+        ? CPU_SECTION_SIZE_LEGACY
+        : sizeof(dosbox::EngineStateCpu);
+
     if (!validate_offset(header.timing_offset, sizeof(dosbox::EngineStateTiming)) ||
         !validate_offset(header.pic_offset, pic_section_size) ||
         !validate_offset(header.keyboard_offset, sizeof(dosbox::EngineStateKeyboard)) ||
-        !validate_offset(header.cpu_offset, sizeof(dosbox::EngineStateCpu)) ||
+        !validate_offset(header.cpu_offset, cpu_section_size) ||
         !validate_offset(header.memory_offset, sizeof(dosbox::EngineStateMemory))) {
         g_last_error = "Invalid section offset";
         return DOSBOX_LIB_ERR_INVALID_STATE;
@@ -1127,8 +1161,10 @@ dosbox_lib_error_t dosbox_lib_load_state(
     ctx->keyboard.rightshift_pressed = kbd.rightshift_pressed != 0;
 
     // Deserialize CPU state (H2: memcpy into local struct)
+    // For V4 and earlier files, the CPU section is only 96 bytes (no GPR fields).
+    // Zero-initialize the struct so new GPR fields default to 0 for legacy saves.
     dosbox::EngineStateCpu cpu{};
-    std::memcpy(&cpu, ptr + header.cpu_offset, sizeof(cpu));
+    std::memcpy(&cpu, ptr + header.cpu_offset, cpu_section_size);
     ctx->cpu_state.cycles = cpu.cycles;
     ctx->cpu_state.cycle_left = cpu.cycle_left;
     ctx->cpu_state.cycle_max = cpu.cycle_max;
@@ -1146,6 +1182,24 @@ dosbox_lib_error_t dosbox_lib_load_state(
     ctx->cpu_state.nmi_active = cpu.nmi_active != 0;
     ctx->cpu_state.nmi_pending = cpu.nmi_pending != 0;
     ctx->cpu_state.halted = cpu.halted != 0;
+    // CPU GPR restore (REQ-SR-002) — write x86 register file from EngineStateCpu
+    {
+        uint32_t gpr[8] = {
+            cpu.reg_eax, cpu.reg_ecx, cpu.reg_edx, cpu.reg_ebx,
+            cpu.reg_esp, cpu.reg_ebp, cpu.reg_esi, cpu.reg_edi
+        };
+        // Segment order: ES(0), CS(1), SS(2), DS(3), FS(4), GS(5)
+        uint16_t seg_val[6] = {
+            cpu.seg_es, cpu.seg_cs, cpu.seg_ss,
+            cpu.seg_ds, cpu.seg_fs, cpu.seg_gs
+        };
+        // seg_phys and seg_limit are not stored in EngineStateCpu; pass zeros
+        // (the V5 CpuGpr extension preserves them when available)
+        uint32_t seg_phys[6]  = {};
+        uint32_t seg_limit[6] = {};
+        dosbox::restore_cpu_gprs(gpr, cpu.reg_eip, cpu.reg_eflags,
+                                 seg_val, seg_phys, seg_limit);
+    }
 
     // Deserialize Memory state (H2: memcpy into local struct)
     dosbox::EngineStateMemory mem{};
@@ -1254,7 +1308,7 @@ dosbox_lib_error_t dosbox_lib_load_state(
         }
 
         // ── Phase 3: Deserialize RAM + VGA sub-blocks ───────────────────
-        // Sub-block directory starts at offset 792 (after GPR data)
+        // Sub-block directory starts at offset 848 (after GPR data)
         size_t dir_offset = dosbox::ENGINE_STATE_SIZE_V5_BASE;
         if (header.total_size > dir_offset + sizeof(dosbox::V5SubBlockDir)) {
             dosbox::V5SubBlockDir dir{};
@@ -1937,6 +1991,13 @@ dosbox_lib_error_t dosbox_lib_midi_set_soundfont(dosbox_lib_handle_t handle, con
     LIB_CHECK_THREAD();
     LIB_REQUIRE(sf2_path != nullptr, DOSBOX_LIB_ERR_NULL_POINTER);
 
+    constexpr std::uintmax_t kMaxSf2Size = 256ULL * 1024 * 1024;  // 256 MB
+    std::error_code ec;
+    auto sz = std::filesystem::file_size(sf2_path, ec);
+    if (ec || sz > kMaxSf2Size) {
+        return DOSBOX_LIB_ERR_INVALID_ARGUMENT;
+    }
+
     dosbox_midi_set_soundfont(sf2_path);
     return DOSBOX_LIB_OK;
 }
@@ -1945,6 +2006,20 @@ dosbox_lib_error_t dosbox_lib_midi_set_romdir(dosbox_lib_handle_t handle, const 
     LIB_VALIDATE_HANDLE(handle);
     LIB_CHECK_THREAD();
     LIB_REQUIRE(rom_dir != nullptr, DOSBOX_LIB_ERR_NULL_POINTER);
+
+    constexpr std::uintmax_t kMaxRomFileSize = 1ULL * 1024 * 1024;  // 1 MB
+    std::error_code ec;
+    if (!std::filesystem::is_directory(rom_dir, ec) || ec) {
+        return DOSBOX_LIB_ERR_INVALID_ARGUMENT;
+    }
+    for (const auto& entry : std::filesystem::directory_iterator(rom_dir, ec)) {
+        if (entry.is_regular_file()) {
+            auto sz = entry.file_size(ec);
+            if (!ec && sz > kMaxRomFileSize) {
+                return DOSBOX_LIB_ERR_INVALID_ARGUMENT;
+            }
+        }
+    }
 
     dosbox_midi_set_romdir(rom_dir);
     return DOSBOX_LIB_OK;

--- a/engine/tests/unit/test_compat_shim.cpp
+++ b/engine/tests/unit/test_compat_shim.cpp
@@ -181,27 +181,6 @@ TEST_F(CompatShimTest, NestedContextGuards) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Step Integration Tests
-// ─────────────────────────────────────────────────────────────────────────────
-
-TEST_F(CompatShimTest, StepSetsContext) {
-    MachineConfig config = MachineConfig::minimal();
-    MachineContext ctx(config);
-    ctx.initialize();
-
-    // Before step, no context should be set
-    EXPECT_FALSE(compat::has_context());
-
-    // Step should set context internally
-    // (Note: After step returns, context may or may not be set
-    // depending on implementation - step uses ContextGuard)
-    ctx.step(1);
-
-    // After step, the ContextGuard in step() should have cleaned up
-    // This tests that the guard properly restores the previous (null) state
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Multiple Context Tests
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/engine/tests/unit/test_dosbox_context.cpp
+++ b/engine/tests/unit/test_dosbox_context.cpp
@@ -72,27 +72,6 @@ TEST(DOSBoxContextTest, DoubleInitializeFails) {
     EXPECT_FALSE(ctx.initialize().has_value());  // Second init fails
 }
 
-TEST(DOSBoxContextTest, StepRequiresInit) {
-    DOSBoxContext ctx;
-
-    auto result = ctx.step(10);
-    EXPECT_FALSE(result.has_value());  // Fails without init
-}
-
-TEST(DOSBoxContextTest, StepUpdatesState) {
-    DOSBoxContext ctx;
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.timing.virtual_ticks_ms, 0u);
-    EXPECT_EQ(ctx.timing.total_cycles, 0u);
-
-    auto result = ctx.step(10);
-    ASSERT_TRUE(result.has_value());
-
-    EXPECT_EQ(ctx.timing.virtual_ticks_ms, 10u);
-    EXPECT_GT(ctx.timing.total_cycles, 0u);
-}
-
 TEST(DOSBoxContextTest, RequestStop) {
     DOSBoxContext ctx;
     ctx.initialize();
@@ -101,10 +80,6 @@ TEST(DOSBoxContextTest, RequestStop) {
 
     ctx.request_stop();
     EXPECT_TRUE(ctx.stop_requested());
-
-    // Step should fail when stop requested
-    auto result = ctx.step(10);
-    EXPECT_FALSE(result.has_value());
 }
 
 TEST(DOSBoxContextTest, Shutdown) {
@@ -120,18 +95,13 @@ TEST(DOSBoxContextTest, Shutdown) {
 TEST(DOSBoxContextTest, Reset) {
     DOSBoxContext ctx;
     ctx.initialize();
-    ctx.step(100);
-
-    EXPECT_GT(ctx.timing.virtual_ticks_ms, 0u);
 
     auto result = ctx.reset();
     ASSERT_TRUE(result.has_value());
 
-    // State should be reset
+    // State should be reset and still initialized
     EXPECT_EQ(ctx.timing.virtual_ticks_ms, 0u);
     EXPECT_EQ(ctx.timing.total_cycles, 0u);
-
-    // But still initialized
     EXPECT_TRUE(ctx.is_initialized());
 }
 
@@ -378,10 +348,6 @@ TEST(DOSBoxContextCApiTest, FullLifecycle) {
     int result = dosbox_init(handle);
     EXPECT_EQ(result, DOSBOX_OK);
 
-    // Step
-    result = dosbox_step(handle, 10);
-    EXPECT_EQ(result, DOSBOX_OK);
-
     // Pause
     result = dosbox_pause(handle);
     EXPECT_EQ(result, DOSBOX_OK);
@@ -401,7 +367,6 @@ TEST(DOSBoxContextCApiTest, FullLifecycle) {
 
 TEST(DOSBoxContextCApiTest, NullHandleReturnsError) {
     EXPECT_NE(dosbox_init(nullptr), DOSBOX_OK);
-    EXPECT_NE(dosbox_step(nullptr, 10), DOSBOX_OK);
     EXPECT_NE(dosbox_destroy(nullptr), DOSBOX_OK);
 }
 
@@ -412,15 +377,11 @@ TEST(DOSBoxContextCApiTest, NullHandleReturnsError) {
 TEST(DOSBoxContextTest, MoveConstruction) {
     DOSBoxContext ctx1;
     ctx1.initialize();
-    ctx1.step(50);
-
-    uint64_t cycles_before = ctx1.timing.total_cycles;
 
     DOSBoxContext ctx2(std::move(ctx1));
 
     // ctx2 should have the state
     EXPECT_TRUE(ctx2.is_initialized());
-    EXPECT_EQ(ctx2.timing.total_cycles, cycles_before);
 
     // ctx1 should be uninitialized
     EXPECT_FALSE(ctx1.is_initialized());
@@ -429,7 +390,6 @@ TEST(DOSBoxContextTest, MoveConstruction) {
 TEST(DOSBoxContextTest, MoveAssignment) {
     DOSBoxContext ctx1;
     ctx1.initialize();
-    ctx1.step(50);
 
     DOSBoxContext ctx2;
 

--- a/engine/tests/unit/test_dosbox_cpu.cpp
+++ b/engine/tests/unit/test_dosbox_cpu.cpp
@@ -279,28 +279,12 @@ TEST(CpuHashTest, CycleAutoAdjustAffectsHash) {
 // Context CPU Integration Tests
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST(ContextCpuTest, StepUpdatesCpuCycles) {
-    DOSBoxContext ctx;
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.cpu_state.cycles, 0);
-
-    // Step 10ms
-    auto result = ctx.step(10);
-    ASSERT_TRUE(result.has_value());
-
-    EXPECT_GT(ctx.cpu_state.cycles, 0);
-}
-
 TEST(ContextCpuTest, ResetClearsCpuState) {
     DOSBoxContext ctx;
     ctx.initialize();
 
-    // Execute some steps
-    ctx.step(100);
-    EXPECT_GT(ctx.cpu_state.cycles, 0);
-
-    // Modify other CPU state
+    // Manually set CPU state to simulate accumulated state
+    ctx.cpu_state.cycles = 30000;
     ctx.cpu_state.halted = true;
     ctx.cpu_state.nmi_active = true;
 
@@ -312,20 +296,6 @@ TEST(ContextCpuTest, ResetClearsCpuState) {
     EXPECT_FALSE(ctx.cpu_state.halted);
     EXPECT_FALSE(ctx.cpu_state.nmi_active);
     EXPECT_TRUE(ctx.cpu_state.nmi_gate);  // Default is true
-}
-
-TEST(ContextCpuTest, CyclesAccumulateAcrossSteps) {
-    DOSBoxContext ctx;
-    ctx.initialize();
-
-    ctx.step(10);
-    int64_t cycles1 = ctx.cpu_state.cycles;
-
-    ctx.step(10);
-    int64_t cycles2 = ctx.cpu_state.cycles;
-
-    // Should accumulate
-    EXPECT_GT(cycles2, cycles1);
 }
 
 TEST(ContextCpuTest, ConfigAppliesCyclesLimit) {
@@ -370,7 +340,7 @@ TEST(CombinedHashTest, BothTimingAndCpuAffectHash) {
     EXPECT_NE(hash2, hash3);
 }
 
-TEST(CombinedHashTest, DeterministicAfterStep) {
+TEST(CombinedHashTest, DeterministicInitialState) {
     ContextConfig config;
     config.cpu_cycles = 3000;
 
@@ -381,11 +351,7 @@ TEST(CombinedHashTest, DeterministicAfterStep) {
     ctx1.initialize();
     ctx2.initialize();
 
-    // Step both by same amount
-    ctx1.step(100);
-    ctx2.step(100);
-
-    // Get hashes
+    // Get hashes of freshly initialized contexts
     set_current_context(&ctx1);
     auto result1 = get_state_hash(HashMode::Fast);
     ASSERT_TRUE(result1.has_value());
@@ -394,7 +360,7 @@ TEST(CombinedHashTest, DeterministicAfterStep) {
     auto result2 = get_state_hash(HashMode::Fast);
     ASSERT_TRUE(result2.has_value());
 
-    // Hashes should be identical (deterministic)
+    // Hashes should be identical (deterministic initial state)
     EXPECT_EQ(result1.value(), result2.value());
 
     // Clean up

--- a/engine/tests/unit/test_dosbox_timing.cpp
+++ b/engine/tests/unit/test_dosbox_timing.cpp
@@ -229,28 +229,13 @@ TEST(TimingHashTest, NoContextProducesPlaceholder) {
 // Context Timing Integration Tests
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST(ContextTimingTest, StepUpdatesTiming) {
-    DOSBoxContext ctx;
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.timing.total_cycles, 0u);
-    EXPECT_EQ(ctx.timing.virtual_ticks_ms, 0u);
-
-    // Step 10ms
-    auto result = ctx.step(10);
-    ASSERT_TRUE(result.has_value());
-
-    EXPECT_GT(ctx.timing.total_cycles, 0u);
-    EXPECT_EQ(ctx.timing.virtual_ticks_ms, 10u);
-}
-
 TEST(ContextTimingTest, ResetClearsTiming) {
     DOSBoxContext ctx;
     ctx.initialize();
 
-    // Execute some steps
-    ctx.step(100);
-    EXPECT_GT(ctx.timing.total_cycles, 0u);
+    // Manually set timing fields to simulate accumulated state
+    ctx.timing.total_cycles = 9000;
+    ctx.timing.virtual_ticks_ms = 3;
 
     // Reset
     ctx.reset();
@@ -258,21 +243,4 @@ TEST(ContextTimingTest, ResetClearsTiming) {
     // Timing should be cleared
     EXPECT_EQ(ctx.timing.total_cycles, 0u);
     EXPECT_EQ(ctx.timing.virtual_ticks_ms, 0u);
-}
-
-TEST(ContextTimingTest, TimingAccumulatesAcrossSteps) {
-    DOSBoxContext ctx;
-    ctx.initialize();
-
-    ctx.step(10);
-    uint64_t cycles1 = ctx.timing.total_cycles;
-    uint32_t ticks1 = ctx.timing.virtual_ticks_ms;
-
-    ctx.step(10);
-    uint64_t cycles2 = ctx.timing.total_cycles;
-    uint32_t ticks2 = ctx.timing.virtual_ticks_ms;
-
-    // Should accumulate
-    EXPECT_GT(cycles2, cycles1);
-    EXPECT_EQ(ticks2, 20u);
 }

--- a/engine/tests/unit/test_machine_context.cpp
+++ b/engine/tests/unit/test_machine_context.cpp
@@ -159,81 +159,8 @@ TEST_F(MachineContextTest, IsInitializedAfterInit) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Step/Run Tests
+// Stop/Run Tests
 // ─────────────────────────────────────────────────────────────────────────────
-
-TEST_F(MachineContextTest, StepRequiresInitialization) {
-    MachineContext ctx(config_);
-
-    auto result = ctx.step(10);
-
-    EXPECT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code(), ErrorCode::InvalidState);
-}
-
-TEST_F(MachineContextTest, StepSucceedsAfterInit) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    auto result = ctx.step(10);
-
-    EXPECT_TRUE(result.has_value());
-}
-
-TEST_F(MachineContextTest, StepReturnsStepCount) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    auto result = ctx.step(10);
-
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), 10u);
-}
-
-TEST_F(MachineContextTest, StepUpdatesVirtualTicks) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.virtual_ticks(), 0u);
-
-    ctx.step(5);
-    EXPECT_EQ(ctx.virtual_ticks(), 5u);
-
-    ctx.step(10);
-    EXPECT_EQ(ctx.virtual_ticks(), 15u);
-}
-
-TEST_F(MachineContextTest, StepUpdatesTotalCycles) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.total_cycles(), 0u);
-
-    ctx.step(10);
-
-    EXPECT_GT(ctx.total_cycles(), 0u);
-}
-
-TEST_F(MachineContextTest, StepSetsRunningState) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    ctx.step(1);
-
-    // After step completes (without stop), state may be Running
-    EXPECT_TRUE(ctx.state() == MachineState::Running ||
-                ctx.state() == MachineState::Initialized);
-}
-
-TEST_F(MachineContextTest, RequestStopStopsExecution) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    ctx.request_stop();
-    ctx.step(1000);
-
-    EXPECT_EQ(ctx.state(), MachineState::Stopped);
-}
 
 TEST_F(MachineContextTest, StopRequestedQueryWorks) {
     MachineContext ctx(config_);
@@ -343,8 +270,6 @@ TEST_F(MachineContextTest, DestructorCallsShutdown) {
 TEST_F(MachineContextTest, ResetReinitializes) {
     MachineContext ctx(config_);
     ctx.initialize();
-    ctx.step(100);
-    EXPECT_GT(ctx.virtual_ticks(), 0u);
 
     auto result = ctx.reset();
 
@@ -416,8 +341,8 @@ TEST_F(MachineContextTest, LastErrorInitiallyEmpty) {
 TEST_F(MachineContextTest, LastErrorSetOnFailure) {
     MachineContext ctx(config_);
 
-    // Try to step without init (will fail)
-    ctx.step(10);
+    // Try to pause without being in Running state (will fail)
+    ctx.pause();
 
     EXPECT_TRUE(ctx.last_error().has_value());
 }
@@ -435,17 +360,6 @@ TEST_F(MachineContextTest, RepeatedInitShutdown) {
     // ASan will catch any leaks
 }
 
-TEST_F(MachineContextTest, ManySteps) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    for (int i = 0; i < 100; i++) {
-        auto result = ctx.step(1);
-        EXPECT_TRUE(result.has_value());
-    }
-
-    EXPECT_EQ(ctx.virtual_ticks(), 100u);
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // IsRunning Query Tests

--- a/engine/tests/unit/test_multi_instance_smoke.cpp
+++ b/engine/tests/unit/test_multi_instance_smoke.cpp
@@ -217,8 +217,8 @@ TEST(MultiInstanceSmoke, IndependentHashesDiffer) {
     ASSERT_TRUE(hashB0.has_value());
     EXPECT_EQ(hashA0.value(), hashB0.value());
 
-    // Step A forward, leave B alone
-    ctxA.step(100);
+    // Modify A's timing directly, leave B alone
+    ctxA.timing.total_cycles += 300000;
 
     auto hashA1 = get_state_hash(&ctxA, HashMode::Fast);
     auto hashB1 = get_state_hash(&ctxB, HashMode::Fast);
@@ -243,7 +243,6 @@ TEST(MultiInstanceSmoke, HashStability) {
     skip_if_no_context();
     DOSBoxContext ctx(ContextConfig::minimal());
     ctx.initialize();
-    ctx.step(50);
 
     auto hash1 = get_state_hash(&ctx, HashMode::Fast);
     auto hash2 = get_state_hash(&ctx, HashMode::Fast);

--- a/src/app/shader_renderer.cpp
+++ b/src/app/shader_renderer.cpp
@@ -11,6 +11,7 @@
 #include <glad/glad.h>
 
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -107,6 +108,14 @@ bool ShaderRenderer::loadPreset(ShaderPreset preset) {
 }
 
 bool ShaderRenderer::loadCustomShader(const std::string& glsl_path) {
+    static constexpr std::uintmax_t kMaxShaderBytes = 65536; // 64 KB (REQ-SEC-038)
+
+    std::error_code ec;
+    auto file_size = std::filesystem::file_size(glsl_path, ec);
+    if (ec || file_size > kMaxShaderBytes) {
+        return false;
+    }
+
     std::ifstream file(glsl_path);
     if (!file.is_open()) {
         return false;

--- a/src/legends/legends_embed_api.cpp
+++ b/src/legends/legends_embed_api.cpp
@@ -1050,6 +1050,7 @@ legends_error_t legends_get_config(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(config_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     *config_out = inst->config;
@@ -1206,6 +1207,7 @@ legends_error_t legends_get_emu_time(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(time_us_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     *time_us_out = inst->time_state.emu_time_us;
@@ -1219,6 +1221,7 @@ legends_error_t legends_get_total_cycles(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(cycles_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     *cycles_out = inst->time_state.total_cycles;
@@ -1239,6 +1242,7 @@ legends_error_t legends_capture_text(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(cells_count_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     size_t required_cells = inst->frame_state.text_cell_count();
@@ -1285,6 +1289,7 @@ legends_error_t legends_capture_rgb(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(size_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     uint16_t width, height;
@@ -1423,6 +1428,7 @@ legends_error_t legends_is_frame_dirty(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(dirty_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     *dirty_out = inst->frame_state.dirty ? 1 : 0;
@@ -1438,6 +1444,7 @@ legends_error_t legends_get_cursor(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
 
     if (x_out != nullptr) { *x_out = inst->frame_state.cursor_x; }
     if (y_out != nullptr) { *y_out = inst->frame_state.cursor_y; }
@@ -1459,6 +1466,7 @@ legends_error_t legends_capture_audio(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(count_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     if (!inst->engine_handle) {
@@ -1477,6 +1485,7 @@ legends_error_t legends_is_audio_active(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(active_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     // Audio is active if the engine was created with audio enabled
@@ -1552,12 +1561,17 @@ legends_error_t legends_text_input(
             const ScancodeMapping& mapping = ASCII_TO_SCANCODE[ch];
 
             if (mapping.scancode != 0) {
+                // REQ-IN-004: Atomicity — verify ALL slots for this character are
+                // available BEFORE enqueueing ANY events. Unshifted chars need 2
+                // slots (key-down + key-up); shifted chars need 4 (shift-down +
+                // key-down + key-up + shift-up). Using addition to avoid unsigned
+                // underflow if size() ever exceeds EFFECTIVE_CAPACITY.
                 size_t slots_needed = mapping.needs_shift ? 4 : 2;
-                size_t available = InputState::EFFECTIVE_CAPACITY - inst->input_state.size();
-                if (available < slots_needed) {
+                if (inst->input_state.size() + slots_needed > InputState::EFFECTIVE_CAPACITY) {
                     LEGENDS_ERROR(LEGENDS_ERR_BUFFER_TOO_SMALL, "Keyboard event queue full");
                 }
 
+                // Capacity confirmed — enqueue the complete sequence atomically.
                 if (mapping.needs_shift) {
                     inst->input_state.enqueue_key(SCANCODE_LSHIFT, true, false);
                 }
@@ -2556,6 +2570,7 @@ legends_error_t legends_get_state_hash(
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
     LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(hash_out != nullptr, LEGENDS_ERR_NULL_POINTER);
 
     // Sync state from engine first to ensure hash consistency
@@ -3183,6 +3198,8 @@ legends_error_t legends_has_capability(
 ) {
     auto* inst = get_instance(handle);
     LEGENDS_REQUIRE(inst != nullptr, LEGENDS_ERR_NULL_HANDLE);
+    LEGENDS_CHECK_THREAD();
+    if (inst->in_step) { return LEGENDS_ERR_REENTRANT_CALL; }
     LEGENDS_REQUIRE(capability_name != nullptr, LEGENDS_ERR_NULL_POINTER);
     LEGENDS_REQUIRE(out != nullptr, LEGENDS_ERR_NULL_POINTER);
 

--- a/tests/unit/test_compat_shim.cpp
+++ b/tests/unit/test_compat_shim.cpp
@@ -187,24 +187,16 @@ TEST_F(CompatShimTest, NestedContextGuards) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Step Integration Tests
+// Initialization Context Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-TEST_F(CompatShimTest, StepSetsContext) {
+TEST_F(CompatShimTest, NoContextAfterInit) {
     MachineConfig config = MachineConfig::minimal();
     MachineContext ctx(config);
     ctx.initialize();
 
-    // Before step, no context should be set
+    // No context should be set on an initialized context
     EXPECT_FALSE(compat::has_context());
-
-    // Step should set context internally
-    // (Note: After step returns, context may or may not be set
-    // depending on implementation - step uses ContextGuard)
-    ctx.step(1);
-
-    // After step, the ContextGuard in step() should have cleaned up
-    // This tests that the guard properly restores the previous (null) state
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_machine_context.cpp
+++ b/tests/unit/test_machine_context.cpp
@@ -163,81 +163,8 @@ TEST_F(MachineContextTest, IsInitializedAfterInit) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Step/Run Tests
+// Stop/Run Tests
 // ─────────────────────────────────────────────────────────────────────────────
-
-TEST_F(MachineContextTest, StepRequiresInitialization) {
-    MachineContext ctx(config_);
-
-    auto result = ctx.step(10);
-
-    EXPECT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code(), ErrorCode::InvalidState);
-}
-
-TEST_F(MachineContextTest, StepSucceedsAfterInit) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    auto result = ctx.step(10);
-
-    EXPECT_TRUE(result.has_value());
-}
-
-TEST_F(MachineContextTest, StepReturnsStepCount) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    auto result = ctx.step(10);
-
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), 10u);
-}
-
-TEST_F(MachineContextTest, StepUpdatesVirtualTicks) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.virtual_ticks(), 0u);
-
-    ctx.step(5);
-    EXPECT_EQ(ctx.virtual_ticks(), 5u);
-
-    ctx.step(10);
-    EXPECT_EQ(ctx.virtual_ticks(), 15u);
-}
-
-TEST_F(MachineContextTest, StepUpdatesTotalCycles) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    EXPECT_EQ(ctx.total_cycles(), 0u);
-
-    ctx.step(10);
-
-    EXPECT_GT(ctx.total_cycles(), 0u);
-}
-
-TEST_F(MachineContextTest, StepSetsRunningState) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    ctx.step(1);
-
-    // After step completes (without stop), state may be Running
-    EXPECT_TRUE(ctx.state() == MachineState::Running ||
-                ctx.state() == MachineState::Initialized);
-}
-
-TEST_F(MachineContextTest, RequestStopStopsExecution) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    ctx.request_stop();
-    ctx.step(1000);
-
-    EXPECT_EQ(ctx.state(), MachineState::Stopped);
-}
 
 TEST_F(MachineContextTest, StopRequestedQueryWorks) {
     MachineContext ctx(config_);
@@ -347,8 +274,6 @@ TEST_F(MachineContextTest, DestructorCallsShutdown) {
 TEST_F(MachineContextTest, ResetReinitializes) {
     MachineContext ctx(config_);
     ctx.initialize();
-    ctx.step(100);
-    EXPECT_GT(ctx.virtual_ticks(), 0u);
 
     auto result = ctx.reset();
 
@@ -420,8 +345,8 @@ TEST_F(MachineContextTest, LastErrorInitiallyEmpty) {
 TEST_F(MachineContextTest, LastErrorSetOnFailure) {
     MachineContext ctx(config_);
 
-    // Try to step without init (will fail)
-    ctx.step(10);
+    // Try to pause without being in Running state (will fail)
+    ctx.pause();
 
     EXPECT_TRUE(ctx.last_error().has_value());
 }
@@ -439,17 +364,6 @@ TEST_F(MachineContextTest, RepeatedInitShutdown) {
     // ASan will catch any leaks
 }
 
-TEST_F(MachineContextTest, ManySteps) {
-    MachineContext ctx(config_);
-    ctx.initialize();
-
-    for (int i = 0; i < 100; i++) {
-        auto result = ctx.step(1);
-        EXPECT_TRUE(result.has_value());
-    }
-
-    EXPECT_EQ(ctx.virtual_ticks(), 100u);
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // IsRunning Query Tests

--- a/tests/unit/test_no_phantom_decls.cpp
+++ b/tests/unit/test_no_phantom_decls.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file test_no_phantom_decls.cpp
+ * @brief Verifies that the 7 phantom forward declarations have been removed
+ *        from machine_context.h (REQ-LC-006).
+ *
+ * Reads the header file at compile time via a build-time path and at test
+ * time by scanning the source file for the banned class names.
+ */
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// The path to the engine header, resolved relative to the source tree.
+// CMake passes LEGENDS_SOURCE_DIR as a compile definition.
+#ifndef LEGENDS_ENGINE_HEADER
+#  define LEGENDS_ENGINE_HEADER "engine/include/aibox/machine_context.h"
+#endif
+
+namespace {
+
+/// Load the header file content from the given path.
+/// Returns an empty string if the file cannot be opened.
+std::string load_file(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        return {};
+    }
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+/// Return true if `line` is a forward declaration of `class_name`.
+/// A forward declaration looks like:  class ClassName;
+bool is_forward_decl(const std::string& line, const std::string& class_name) {
+    // Look for "class <ClassName>;" with optional leading whitespace.
+    const std::string pattern = "class " + class_name + ";";
+    auto pos = line.find(pattern);
+    if (pos == std::string::npos) {
+        return false;
+    }
+    // Ensure the text before "class" is only whitespace (not a comment).
+    const std::string before = line.substr(0, pos);
+    for (char c : before) {
+        if (c != ' ' && c != '\t') {
+            return false;  // e.g. "// class Foo;" is a comment, not a decl
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+class NoPhantomDeclsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Attempt to open the header relative to the working directory.
+        // When run from the build directory the relative path should resolve.
+        content_ = load_file(LEGENDS_ENGINE_HEADER);
+        if (content_.empty()) {
+            // Fallback: try the absolute path baked in at build time (if any).
+            GTEST_SKIP() << "Could not open " << LEGENDS_ENGINE_HEADER
+                         << " — skipping phantom-decl scan";
+        }
+    }
+
+    std::string content_;
+
+    /// Assert that no active (non-commented) forward declaration of
+    /// `class_name` exists in the header.
+    void assert_no_forward_decl(const std::string& class_name) {
+        std::istringstream stream(content_);
+        std::string line;
+        int lineno = 0;
+        while (std::getline(stream, line)) {
+            ++lineno;
+            EXPECT_FALSE(is_forward_decl(line, class_name))
+                << "Phantom forward declaration found in machine_context.h"
+                << " at line " << lineno << ": \"" << line << "\"\n"
+                << "REQ-LC-006 requires class " << class_name
+                << " to have been removed.";
+        }
+    }
+};
+
+TEST_F(NoPhantomDeclsTest, NoVgaContextForwardDecl) {
+    assert_no_forward_decl("VgaContext");
+}
+
+TEST_F(NoPhantomDeclsTest, NoDosKernelForwardDecl) {
+    assert_no_forward_decl("DosKernel");
+}
+
+TEST_F(NoPhantomDeclsTest, NoPicControllerForwardDecl) {
+    assert_no_forward_decl("PicController");
+}
+
+TEST_F(NoPhantomDeclsTest, NoPitTimerForwardDecl) {
+    assert_no_forward_decl("PitTimer");
+}
+
+TEST_F(NoPhantomDeclsTest, NoKeyboardControllerForwardDecl) {
+    assert_no_forward_decl("KeyboardController");
+}
+
+TEST_F(NoPhantomDeclsTest, NoMouseControllerForwardDecl) {
+    assert_no_forward_decl("MouseController");
+}
+
+TEST_F(NoPhantomDeclsTest, NoSoundSubsystemForwardDecl) {
+    assert_no_forward_decl("SoundSubsystem");
+}

--- a/tests/unit/test_shader_size_limit.cpp
+++ b/tests/unit/test_shader_size_limit.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024-2025 Charles Hoskinson and Contributors
+//
+// Unit tests for REQ-SEC-038: loadCustomShader() must reject files > 64 KB.
+
+#include "app/shader_renderer.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace legends {
+namespace {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write `byte_count` bytes of filler to `path`.
+static void writeFillFile(const std::filesystem::path& path,
+                          std::size_t byte_count,
+                          char fill = 'x') {
+    std::ofstream out(path, std::ios::binary);
+    ASSERT_TRUE(out.is_open()) << "Could not open " << path;
+    const std::string chunk(1024, fill);
+    std::size_t remaining = byte_count;
+    while (remaining >= chunk.size()) {
+        out.write(chunk.data(), static_cast<std::streamsize>(chunk.size()));
+        remaining -= chunk.size();
+    }
+    if (remaining > 0) {
+        out.write(chunk.data(), static_cast<std::streamsize>(remaining));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REQ-SEC-038 tests
+// ---------------------------------------------------------------------------
+
+// A file larger than 64 KB must be rejected before any GL call is attempted.
+TEST(ShaderSizeLimit, OversizedFileIsRejected) {
+    const auto tmp = std::filesystem::temp_directory_path() /
+                     "legends_test_shader_oversized.glsl";
+
+    // Write 65537 bytes — one byte over the 64 KB limit.
+    writeFillFile(tmp, 65537);
+
+    ShaderRenderer renderer;
+    EXPECT_FALSE(renderer.loadCustomShader(tmp.string()))
+        << "loadCustomShader must return false for a file larger than 64 KB";
+
+    std::filesystem::remove(tmp);
+}
+
+// A file within the 64 KB limit must not be rejected due to size.
+// (Compilation will fail without a GL context, but that is a different path.)
+TEST(ShaderSizeLimit, UndersizedFileIsNotRejectedForSize) {
+    const auto tmp = std::filesystem::temp_directory_path() /
+                     "legends_test_shader_small.glsl";
+
+    // Minimal valid-looking GLSL fragment shader — well under 64 KB.
+    {
+        std::ofstream out(tmp);
+        ASSERT_TRUE(out.is_open()) << "Could not open " << tmp;
+        out << "#version 330 core\n"
+               "out vec4 FragColor;\n"
+               "void main() { FragColor = vec4(1.0); }\n";
+    }
+
+    ShaderRenderer renderer;
+    // The call may return false due to the absence of a GL context, but the
+    // reason must NOT be the file size.  We verify this by confirming that
+    // file_size(path) <= 65536 before calling, and that the file itself
+    // can be opened — both preconditions for passing the size gate.
+    std::error_code ec;
+    auto sz = std::filesystem::file_size(tmp, ec);
+    ASSERT_FALSE(ec) << "file_size() failed: " << ec.message();
+    ASSERT_LE(sz, 65536u) << "Test file unexpectedly exceeds 64 KB";
+
+    // We don't assert the return value because GL may not be available,
+    // but we do assert the call completes without crashing or throwing.
+    (void)renderer.loadCustomShader(tmp.string());
+
+    std::filesystem::remove(tmp);
+}
+
+} // namespace
+} // namespace legends


### PR DESCRIPTION
## Summary

- Close 6 of 8 beta blockers (2 were already resolved on master), moving EARS score from 26/50 to 31/50
- REQ-LC-005: Remove dual runtime path — delete `dosbox_step()` and `MachineContext::step()`, update 9 test files
- REQ-TH-004: Add `std::mutex` to MixerState for thread-safe compound access from audio callback
- REQ-EX-004: Expand reentrancy guard (`in_step` check) to 11 additional API functions
- REQ-IN-004: Fix text_input atomicity — pre-check slot capacity before enqueueing any events
- REQ-SR-002: Serialize CPU GPR (EAX-EDI, EIP, EFLAGS, 6 segment registers) in save state, with backward-compat for V4 files
- REQ-SEC-038: Enforce 64 KB max shader file size in `loadCustomShader()`
- REQ-SEC-039: Enforce 256 MB soundfont and 1 MB ROM file size limits

## Test plan

- [ ] Verify build passes on all 3 platforms (Windows, Linux, macOS)
- [ ] Run full test suite — all previously-passing tests should still pass
- [ ] Run TSan build to verify mixer mutex resolves data races
- [ ] Verify save/load round-trip preserves CPU register state
- [ ] Verify oversized shader/soundfont files are rejected